### PR TITLE
Fix GitHub Actions OIDC Token Request Error

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
- Added github_token parameter to both claude.yml and claude-code-review.yml
- This resolves the "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL" error
- The GITHUB_TOKEN is automatically provided by GitHub Actions
- Fixes issue where OIDC token generation was failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)