### PR TITLE
Resolve Docker Build Dependency Installation Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get install -y \
     libgomp1 \
     libgl1-mesa-glx \
     # 圖像處理依賴
-    libglib2.0-0 \
     libxcb1 \
     libxdamage1 \
     libxfixes3 \


### PR DESCRIPTION
The Dockerfile had libglib2.0-0 listed twice in the apt-get install command (lines 25 and 32), which was causing the build to fail with exit code 100. Removed the duplicate entry to resolve the build error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)