### PR TITLE
Resolve Docker Build Package Installation Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,14 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     DEBIAN_FRONTEND=noninteractive
 
 # 安裝系統依賴
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     # OpenCV 依賴
     libglib2.0-0 \
     libsm6 \
     libxext6 \
     libxrender-dev \
     libgomp1 \
-    libgl1-mesa-glx \
+    libgl1 \
     # 圖像處理依賴
     libxcb1 \
     libxdamage1 \


### PR DESCRIPTION
- Changed libgl1-mesa-glx to libgl1 for Debian Bullseye compatibility
- Added --no-install-recommends flag to reduce package conflicts
- Resolves Docker build error with exit code 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)