### PR TITLE
Resolve NPM Build Process Failure

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",
-    "react-scripts": "^0.0.0",
+    "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {


### PR DESCRIPTION
The Docker build was failing with exit code 127 because react-scripts was set to an invalid version (^0.0.0), causing the npm run build command to fail. Updated to version 5.0.1 which is compatible with React 18.2.0.

Fixes the "command not found" error during Docker image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)